### PR TITLE
Fix package dependency installation

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -22,7 +22,7 @@ module.exports =
       type: 'boolean'
 
   activate: ->
-    require('atom-package-deps').install()
+    require('atom-package-deps').install('linter-pug')
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-pug.executablePath',
       (executablePath) =>


### PR DESCRIPTION
The name of the package needed to be manually specified here to work properly when cloned.