### PR TITLE
Move to Trsusty based builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ os:
   - linux
 
 ### Generic setup follows ###
+dist: trusty
+
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh


### PR DESCRIPTION
Atom v1.18.0 requires a minimum of Trusty now, so force Travis to the
newer image.