### PR TITLE
[Linter] Invalid Linter received

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -123,6 +123,7 @@ module.exports = {
       grammarScopes: ['source.jade', 'source.pug'],
       scope: 'file',
       lintOnFly: true,
+      lintsOnChange: true,
 
       lint: async (textEditor) => {
         if (!atom.workspace.isTextEditor(textEditor)) {


### PR DESCRIPTION
Hi, thanks for your work on this project so far. I just encountered a problem while installing the plugin in atom. Warning on startup:

```
[Linter] Invalid Linter received
These issues were encountered while registering a Linter named 'pug-lint'
  • Linter.lintsOnChange must be a boolean
```

Fixed this by adding `lintsOnChange` to the registration process.