### PR TITLE
fix: correctly declare the provider for v2 API

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -122,7 +122,7 @@ module.exports = {
       name: 'pug-lint',
       grammarScopes: ['source.jade', 'source.pug'],
       scope: 'file',
-      lintOnFly: true,
+      lintsOnChange: true,
 
       lint: async (textEditor) => {
         if (!atom.workspace.isTextEditor(textEditor)) {


### PR DESCRIPTION
The Linter v2 API changed `lintOnFly` to `lintsOnChange`, this change was missed when doing the initial update in 2d9798a4.

Closes #23.
Fixes #24.