### PR TITLE
Update to commitlint v6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@commitlint/config-conventional": "^5.2.3",
     "@commitlint/travis-cli": "^5.2.8",
     "@semantic-release/apm-config": "^1.0.2",
-    "commitlint": "^5.2.8",
+    "commitlint": "^6.0.1",
     "eslint": "^4.14.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^5.2.3",
-    "@commitlint/travis-cli": "^5.2.8",
+    "@commitlint/travis-cli": "^6.0.1",
     "@semantic-release/apm-config": "^1.0.2",
     "commitlint": "^6.0.1",
     "eslint": "^4.14.0",


### PR DESCRIPTION
Update to `commitlint@^6.0.1`.

Closes #28, #29.