### PR TITLE
fix(package): pin pug-lint to version 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "atom-linter": "^10.0.0",
     "object-assign": "^4.1.0",
-    "pug-lint": "^2.1.9",
+    "pug-lint": "2.5.0",
     "resolve": "^1.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Now that releases are automated, pinning the version of `pug-lint` shouldn't be too big of an issue.

Closes #2
Closes #8