### PR TITLE
Explicitly set _basePath on linter instance

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -166,6 +166,7 @@ module.exports = {
         }
 
         const linter = new (await getPugLint(projectDir))();
+        linter._basePath = projectDir;
         linter.configure(rules);
         const results = linter.checkString(fileText, filePath);
         return results.map(res => ({


### PR DESCRIPTION
Sometimes required when puglintrc extends a rules file that is referenced with a relative path