### PR TITLE
fix(config): set _basePath on linter instance

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -166,7 +166,9 @@ module.exports = {
         }
 
         const linter = new (await getPugLint(projectDir))();
+        linter._basePath = projectDir;
         linter.configure(rules);
+        
         const results = linter.checkString(fileText, filePath);
         return results.map(res => ({
           severity: 'error',

--- a/lib/init.js
+++ b/lib/init.js
@@ -166,7 +166,8 @@ module.exports = {
         }
 
         const linter = new (await getPugLint(projectDir))();
-        linter['_basePath'] = projectDir;
+        // eslint-disable-next-line no-underscore-dangle
+        linter._basePath = projectDir;
         linter.configure(rules);
 
         const results = linter.checkString(fileText, filePath);

--- a/lib/init.js
+++ b/lib/init.js
@@ -166,7 +166,7 @@ module.exports = {
         }
 
         const linter = new (await getPugLint(projectDir))();
-        linter._basePath = projectDir; // eslint-disable-line no-underscore-dangle
+        linter['_basePath'] = projectDir;
         linter.configure(rules);
 
         const results = linter.checkString(fileText, filePath);

--- a/lib/init.js
+++ b/lib/init.js
@@ -166,9 +166,9 @@ module.exports = {
         }
 
         const linter = new (await getPugLint(projectDir))();
-        linter._basePath = projectDir;
+        linter._basePath = projectDir; // eslint-disable-line no-underscore-dangle
         linter.configure(rules);
-        
+
         const results = linter.checkString(fileText, filePath);
         return results.map(res => ({
           severity: 'error',


### PR DESCRIPTION
Sometimes required when puglintrc extends a rules file that is referenced with a relative path